### PR TITLE
Directrix: Alter way kill reward is done

### DIFF
--- a/Directrix/map.xml
+++ b/Directrix/map.xml
@@ -211,9 +211,6 @@
     <item>stone sword</item>
 </itemremove>
 <killreward>
-    <filter>
-        <kill-streak count="1" repeat="true"/>
-    </filter>
     <item amount="3">arrow</item>
 </killreward>
 <gamerules>


### PR DESCRIPTION
Because https://github.com/Electroid/PGM/issues/233 is an issue, and because the way the kill reward was done originally is completely unnecessary, I tweaked it so kill rewards will work  