### PR TITLE
 Riverbank: Fix kill reward item name to match villager trades

### DIFF
--- a/Riverbank/map.xml
+++ b/Riverbank/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.3.5">
 <name>Riverbank</name> 
-<version>1.0.0</version> 
+<version>1.0.1</version> 
 <objective>To win destroy both of the enemy team's monuments.</objective>
 <authors>
     <author uuid="fe3608b7-d105-4029-8800-34b3147065b6"/> <!-- rockymine -->
@@ -133,7 +133,7 @@
     <item>gold ingot</item>
 </itemkeep>
 <killreward>
-    <item name="Fine Gold" lore="Use this as currency.">gold ingot</item>
+    <item name="`lFine Gold" lore="Use this as currency.">gold ingot</item>
     <item amount="8">arrow</item>
 </killreward>
 <multitrade/>


### PR DESCRIPTION
Currently, the map is broken as the villager expects the item trades to have a bold title (see below).

![image](https://user-images.githubusercontent.com/8608892/72683592-9a074e00-3ad0-11ea-818e-7e22d24dd3e5.png)

This change adds the bold formatting to the kill reward item thus fixing the issue.

I would assume this bold/non-bold issue worked before, either that or Yoyo is a bad map dev 🤔
