### PR TITLE
Piston KoTH: Add iron swords to tool repair

### DIFF
--- a/Piston KoTH/map.xml
+++ b/Piston KoTH/map.xml
@@ -98,6 +98,7 @@
 <timelock>on</timelock>
 <toolrepair>
     <tool>stone sword</tool>
+    <tool>iron sword</tool>
     <tool>bow</tool>
 </toolrepair>
 <itemremove>

--- a/Piston KoTH/map.xml
+++ b/Piston KoTH/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.3.3">
 <name>Piston KoTH</name>
-<version>1.1.2</version>
+<version>1.1.3</version>
 <objective>Control the capture points!</objective>
 <authors>
     <author uuid="5e1c0b5d-cfdd-4e10-95cd-c53f8ee92150"/> <!-- Pandaboy999 -->


### PR DESCRIPTION
There's a spawner in mid that spawns iron swords, but they kinda end up stacking up by the end of a match