### PR TITLE
cos(tnt): Add alerts about the diamond boots to reduce confusion

### DIFF
--- a/cos(tnt)/map.xml
+++ b/cos(tnt)/map.xml
@@ -422,6 +422,7 @@
 <broadcasts>
     <alert after="1s">`a`oEvery `65 `a`ominutes there is an iron supply drop</alert>
     <alert after="2s">`a`oEvery `610 `a`ominutes there is a diamond supply drop</alert>
+    <alert after="10m30s" every="2m30s">Diamond boots give anti-knockback to the player wearing them!</alert>
 </broadcasts>
 <itemremove>
     <item>diamond pickaxe</item>

--- a/cos(tnt)/map.xml
+++ b/cos(tnt)/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.3.5">
 <name>cos(tnt)</name>
-<version>0.83</version>
+<version>0.84</version>
 <objective>You must be the first team to get to 2,750 points before time runs out!</objective>
 <authors>
     <author uuid="dad8b95c-cf6a-44df-982e-8c8dd70201e0"/> <!-- ElectroidFilms -->


### PR DESCRIPTION
People always seem to be confused about this game mechanic, hopefully an alert explaining how it gives anti-kb will help? The alert will go off shortly after the first diamond block drop and then repeat every couple of mins.

If it gets spammy feel free to increase the time period between each frequency.